### PR TITLE
Impl std::error::Error for JoinError

### DIFF
--- a/src/tokio_wasm/task/join_handle.rs
+++ b/src/tokio_wasm/task/join_handle.rs
@@ -102,3 +102,11 @@ where
 /// Returned when a task failed to execute to completion.
 #[derive(Debug)]
 pub struct JoinError;
+
+impl fmt::Display for JoinError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("task failed to execute to completion")
+    }
+}
+
+impl std::error::Error for JoinError {}


### PR DESCRIPTION
This is important to run `try_join!` with JoinHandle.