### PR TITLE
Remove `remove_inactive_workers` from worker pool

### DIFF
--- a/tokio_with_wasm/src/glue/task/mod.rs
+++ b/tokio_with_wasm/src/glue/task/mod.rs
@@ -33,7 +33,6 @@ thread_local! {
 async fn manage_pool() {
     loop {
         WORKER_POOL.with(|worker_pool| {
-            worker_pool.remove_inactive_workers();
             worker_pool.flush_queued_tasks();
         });
         let promise = Promise::new(&mut |resolve, _reject| {

--- a/tokio_with_wasm/src/glue/task/pool.rs
+++ b/tokio_with_wasm/src/glue/task/pool.rs
@@ -229,21 +229,6 @@ impl WorkerPool {
         Ok(())
     }
 
-    pub fn remove_inactive_workers(&self) {
-        let mut idle_workers = self.pool_state.idle_workers.borrow_mut();
-        let current_timestamp = now();
-        idle_workers.retain(|managed_worker| {
-            let passed_time =
-                current_timestamp - *managed_worker.deactivated_time.borrow();
-            let is_active = passed_time < 10000.0; // 10 seconds
-            if !is_active {
-                managed_worker.worker.terminate();
-                *self.pool_state.total_workers_count.borrow_mut() -= 1;
-            }
-            is_active
-        });
-    }
-
     pub fn flush_queued_tasks(&self) {
         while *self.pool_state.total_workers_count.borrow() < MAX_WORKERS {
             let mut queued_tasks = self.pool_state.queued_tasks.borrow_mut();


### PR DESCRIPTION
The function does not remove workers. It removes tasks that haven't run in the last 10 seconds. This leads to tasks that have yielded awaiting a waker, such as awaiting the receieve end of a mpsc channel, being removed from the task pool silently.