### PR TITLE
Support non-browser wasm environments

### DIFF
--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -13,6 +13,7 @@ all-features = true
 [features]
 # https://github.com/tokio-rs/tokio/blob/master/tokio/Cargo.toml
 default = []
+non_browser = []
 full = ["macros", "sync", "time", "rt", "rt-multi-thread"]
 macros = ["tokio/macros"]
 sync = ["tokio/sync"]

--- a/package/src/glue/common/thread_check.rs
+++ b/package/src/glue/common/thread_check.rs
@@ -1,9 +1,15 @@
 use std::cell::LazyCell;
-use web_sys::window;
 
 thread_local! {
   pub static IS_MAIN_THREAD: LazyCell<bool> =
-    LazyCell::new(|| window().is_some());
+    LazyCell::new(|| {
+      #[cfg(not(feature = "non_browser"))] {
+        web_sys::window().is_some()
+      }
+      #[cfg(feature = "non_browser")] {
+        true
+      }
+    });
 }
 
 pub fn is_main_thread() -> bool {


### PR DESCRIPTION
I am using this change to support compilation to `wasm32-unknown-unknown` for Cloudflare Workers, though I presume this should achieve the same goal for use with any non-browser environment.

Without this, we encounter the error: "Calling `spawn` in a blocking thread is not supported yet."

I made the `non_browser` feature opt-in so that the default behavior remains to check for a browser window. This allows `tokio_with_wasm` to be used as a workspace-level dependency, and individual crates that need to disable the browser check can enable the `non_browser` feature. Hence, we provide maximal safety by default, and a client must opt out to achieve lower safety.

This would stand in contrast to adding a `browser` feature that is included in the default feature set; if `tokio_with_wasm` is used as a workspace-level dependency and default features are disabled at the workspace level, then `browser` must be re-enabled by individual crates. The maximal safety in this case becomes opt-in, which seems less desirable and error-prone, since a client might erroneously fail to leverage the browser check.

It would be ideal if there was a way to better differentiate between browser and non-browser environments when compiling to a `wasm32-unknown-unknown` target, thereby eliminating the need for a feature-based implementation. I am unaware, however, of any method by which to achieve this.